### PR TITLE
Indicate Python 3 support in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,8 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'Topic :: Software Development'
     ],
 )


### PR DESCRIPTION
This change indicates that the package supports Python 3. This ensures it'll pass automated checks such as https://caniusepython3.com/project/responses .

This would be very useful when automatically gathering all packages that do not yet support Python 3 in the projects that I'm working on.
